### PR TITLE
Handling rate limiting of emails

### DIFF
--- a/.github/workflows/feature.yml
+++ b/.github/workflows/feature.yml
@@ -5,6 +5,7 @@ on:
         branches:
             - feature/**
             - GAP-**
+            - bug/**
         paths-ignore:
             - '*.md'
 

--- a/src/email/email.service.spec.ts
+++ b/src/email/email.service.spec.ts
@@ -42,6 +42,7 @@ describe('EmailService', () => {
         const reference = 'test-reference';
 
         await service.send(email, templateId, personalisation, reference);
+
         const mockSendEmail = NotifyClient.mock.instances[0].sendEmail;
         expect(mockSendEmail).toHaveBeenCalledTimes(1);
         expect(mockSendEmail).toHaveBeenCalledWith(templateId, email, {

--- a/src/email/email.service.ts
+++ b/src/email/email.service.ts
@@ -27,6 +27,7 @@ export class EmailService {
                 reference: reference,
             });
         } catch (error) {
+            console.debug(error);
             const statusCode = error.response.status;
             switch (statusCode) {
                 case '429':
@@ -42,7 +43,6 @@ export class EmailService {
                     );
                     break;
                 default:
-                    console.debug(error);
                     throw new Error(
                         `Failed to send email with status code: ${statusCode} ${{
                             emailAddress: emailAddress,

--- a/src/email/email.service.ts
+++ b/src/email/email.service.ts
@@ -42,6 +42,7 @@ export class EmailService {
                     );
                     break;
                 default:
+                    console.debug(error);
                     throw new Error(
                         `Failed to send email with status code: ${statusCode} ${{
                             emailAddress: emailAddress,

--- a/src/email/email.service.ts
+++ b/src/email/email.service.ts
@@ -27,7 +27,7 @@ export class EmailService {
                 reference: reference,
             });
         } catch (error) {
-            const statusCode = error.response.data.status_code;
+            const statusCode = error.response.status;
             switch (statusCode) {
                 case '429':
                     console.info(

--- a/src/email/email.service.ts
+++ b/src/email/email.service.ts
@@ -21,10 +21,37 @@ export class EmailService {
         personalisation: Personalisation,
         reference: string,
     ) {
-        await this.notifyClient.sendEmail(templateId, emailAddress, {
-            personalisation: personalisation,
-            reference: reference,
-        });
+        try {
+            await this.notifyClient.sendEmail(templateId, emailAddress, {
+                personalisation: personalisation,
+                reference: reference,
+            });
+        } catch (error) {
+            const statusCode = error.response.data.status_code;
+            switch (statusCode) {
+                case '429':
+                    console.info(
+                        'Hit rate limiting while sending emails, waiting for one minute then retrying.',
+                    );
+                    await new Promise((resolve) => setTimeout(resolve, 60000));
+                    await this.send(
+                        templateId,
+                        emailAddress,
+                        personalisation,
+                        reference,
+                    );
+                    break;
+                default:
+                    throw new Error(
+                        `Failed to send email with status code: ${statusCode} ${{
+                            emailAddress: emailAddress,
+                            templateId: templateId,
+                            personalisation: personalisation,
+                            reference: reference,
+                        }}`,
+                    );
+            }
+        }
     }
 }
 

--- a/src/notifications/notifications.service.ts
+++ b/src/notifications/notifications.service.ts
@@ -147,14 +147,13 @@ export class NotificationsService {
             const newsletters = await this.newsletterService.findAllByType(
                 NewsletterType.NEW_GRANTS,
             );
+            const personalisation = {
+                'Link to new grant summary page': new URL(
+                    `grants?searchTerm=&from-day=${last7days.day}&from-month=${last7days.month}&from-year=${last7days.year}&to-day=${today.day}&to-month=${today.month}&to-year=${today.year}`,
+                    this.HOST,
+                ),
+            };
             for (const newsletter of newsletters) {
-                const personalisation = {
-                    'Link to new grant summary page': new URL(
-                        `grants?searchTerm=&from-day=${last7days.day}&from-month=${last7days.month}&from-year=${last7days.year}&to-day=${today.day}&to-month=${today.month}&to-year=${today.year}`,
-                        this.HOST,
-                    ),
-                };
-
                 this.emailService.send(
                     await newsletter.user.decryptEmail(),
                     this.NEW_GRANTS_EMAIL_TEMPLATE_ID,


### PR DESCRIPTION
We have been hitting 3000 emails per minute in our production env, further emails error with the code 429 and are not sent.

This PR ensures we catch these errors, wait for a minute before retrying to send the email. And logs other errors in a more readable manner