### PR TITLE
Adds delete function by sub and email

### DIFF
--- a/src/migration/1700651901473-cascade-delete-user.ts
+++ b/src/migration/1700651901473-cascade-delete-user.ts
@@ -1,32 +1,71 @@
-import {MigrationInterface, QueryRunner} from "typeorm";
+import { MigrationInterface, QueryRunner } from 'typeorm';
 
 export class cascadeDeleteUser1700651901473 implements MigrationInterface {
-    name = 'cascadeDeleteUser1700651901473'
+    name = 'cascadeDeleteUser1700651901473';
 
     public async up(queryRunner: QueryRunner): Promise<void> {
-        await queryRunner.query(`ALTER TABLE "saved_search" DROP CONSTRAINT "FK_397e5fcfff614ace7edf6831d5b"`);
-        await queryRunner.query(`ALTER TABLE "subscription" DROP CONSTRAINT "FK_cc906b4bc892b048f1b654d2aa0"`);
-        await queryRunner.query(`ALTER TABLE "saved_search_notification" DROP CONSTRAINT "FK_a9dd34a7c89d31227a4b4e2eb85"`);
-        await queryRunner.query(`ALTER TABLE "unsubscribe" DROP CONSTRAINT "FK_f051628403f51d0b0e11c1aabf4"`);
-        await queryRunner.query(`ALTER TABLE "newsletter" DROP CONSTRAINT "FK_20f63020913bbfdc1835e080549"`);
-        await queryRunner.query(`ALTER TABLE "saved_search" ADD CONSTRAINT "FK_397e5fcfff614ace7edf6831d5b" FOREIGN KEY ("userId") REFERENCES "gap_user"("id") ON DELETE CASCADE ON UPDATE NO ACTION`);
-        await queryRunner.query(`ALTER TABLE "subscription" ADD CONSTRAINT "FK_cc906b4bc892b048f1b654d2aa0" FOREIGN KEY ("userId") REFERENCES "gap_user"("id") ON DELETE CASCADE ON UPDATE NO ACTION`);
-        await queryRunner.query(`ALTER TABLE "saved_search_notification" ADD CONSTRAINT "FK_a9dd34a7c89d31227a4b4e2eb85" FOREIGN KEY ("userId") REFERENCES "gap_user"("id") ON DELETE CASCADE ON UPDATE NO ACTION`);
-        await queryRunner.query(`ALTER TABLE "unsubscribe" ADD CONSTRAINT "FK_f051628403f51d0b0e11c1aabf4" FOREIGN KEY ("userId") REFERENCES "gap_user"("id") ON DELETE CASCADE ON UPDATE NO ACTION`);
-        await queryRunner.query(`ALTER TABLE "newsletter" ADD CONSTRAINT "FK_20f63020913bbfdc1835e080549" FOREIGN KEY ("userId") REFERENCES "gap_user"("id") ON DELETE CASCADE ON UPDATE NO ACTION`);
+        await queryRunner.query(
+            `ALTER TABLE "saved_search" DROP CONSTRAINT "FK_397e5fcfff614ace7edf6831d5b"`,
+        );
+        await queryRunner.query(
+            `ALTER TABLE "subscription" DROP CONSTRAINT "FK_cc906b4bc892b048f1b654d2aa0"`,
+        );
+        await queryRunner.query(
+            `ALTER TABLE "saved_search_notification" DROP CONSTRAINT "FK_a9dd34a7c89d31227a4b4e2eb85"`,
+        );
+        await queryRunner.query(
+            `ALTER TABLE "unsubscribe" DROP CONSTRAINT "FK_f051628403f51d0b0e11c1aabf4"`,
+        );
+        await queryRunner.query(
+            `ALTER TABLE "newsletter" DROP CONSTRAINT "FK_20f63020913bbfdc1835e080549"`,
+        );
+        await queryRunner.query(
+            `ALTER TABLE "saved_search" ADD CONSTRAINT "FK_397e5fcfff614ace7edf6831d5b" FOREIGN KEY ("userId") REFERENCES "gap_user"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+        );
+        await queryRunner.query(
+            `ALTER TABLE "subscription" ADD CONSTRAINT "FK_cc906b4bc892b048f1b654d2aa0" FOREIGN KEY ("userId") REFERENCES "gap_user"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+        );
+        await queryRunner.query(
+            `ALTER TABLE "saved_search_notification" ADD CONSTRAINT "FK_a9dd34a7c89d31227a4b4e2eb85" FOREIGN KEY ("userId") REFERENCES "gap_user"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+        );
+        await queryRunner.query(
+            `ALTER TABLE "unsubscribe" ADD CONSTRAINT "FK_f051628403f51d0b0e11c1aabf4" FOREIGN KEY ("userId") REFERENCES "gap_user"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+        );
+        await queryRunner.query(
+            `ALTER TABLE "newsletter" ADD CONSTRAINT "FK_20f63020913bbfdc1835e080549" FOREIGN KEY ("userId") REFERENCES "gap_user"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+        );
     }
 
     public async down(queryRunner: QueryRunner): Promise<void> {
-        await queryRunner.query(`ALTER TABLE "newsletter" DROP CONSTRAINT "FK_20f63020913bbfdc1835e080549"`);
-        await queryRunner.query(`ALTER TABLE "unsubscribe" DROP CONSTRAINT "FK_f051628403f51d0b0e11c1aabf4"`);
-        await queryRunner.query(`ALTER TABLE "saved_search_notification" DROP CONSTRAINT "FK_a9dd34a7c89d31227a4b4e2eb85"`);
-        await queryRunner.query(`ALTER TABLE "subscription" DROP CONSTRAINT "FK_cc906b4bc892b048f1b654d2aa0"`);
-        await queryRunner.query(`ALTER TABLE "saved_search" DROP CONSTRAINT "FK_397e5fcfff614ace7edf6831d5b"`);
-        await queryRunner.query(`ALTER TABLE "newsletter" ADD CONSTRAINT "FK_20f63020913bbfdc1835e080549" FOREIGN KEY ("userId") REFERENCES "gap_user"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
-        await queryRunner.query(`ALTER TABLE "unsubscribe" ADD CONSTRAINT "FK_f051628403f51d0b0e11c1aabf4" FOREIGN KEY ("userId") REFERENCES "gap_user"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
-        await queryRunner.query(`ALTER TABLE "saved_search_notification" ADD CONSTRAINT "FK_a9dd34a7c89d31227a4b4e2eb85" FOREIGN KEY ("userId") REFERENCES "gap_user"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
-        await queryRunner.query(`ALTER TABLE "subscription" ADD CONSTRAINT "FK_cc906b4bc892b048f1b654d2aa0" FOREIGN KEY ("userId") REFERENCES "gap_user"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
-        await queryRunner.query(`ALTER TABLE "saved_search" ADD CONSTRAINT "FK_397e5fcfff614ace7edf6831d5b" FOREIGN KEY ("userId") REFERENCES "gap_user"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+        await queryRunner.query(
+            `ALTER TABLE "newsletter" DROP CONSTRAINT "FK_20f63020913bbfdc1835e080549"`,
+        );
+        await queryRunner.query(
+            `ALTER TABLE "unsubscribe" DROP CONSTRAINT "FK_f051628403f51d0b0e11c1aabf4"`,
+        );
+        await queryRunner.query(
+            `ALTER TABLE "saved_search_notification" DROP CONSTRAINT "FK_a9dd34a7c89d31227a4b4e2eb85"`,
+        );
+        await queryRunner.query(
+            `ALTER TABLE "subscription" DROP CONSTRAINT "FK_cc906b4bc892b048f1b654d2aa0"`,
+        );
+        await queryRunner.query(
+            `ALTER TABLE "saved_search" DROP CONSTRAINT "FK_397e5fcfff614ace7edf6831d5b"`,
+        );
+        await queryRunner.query(
+            `ALTER TABLE "newsletter" ADD CONSTRAINT "FK_20f63020913bbfdc1835e080549" FOREIGN KEY ("userId") REFERENCES "gap_user"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`,
+        );
+        await queryRunner.query(
+            `ALTER TABLE "unsubscribe" ADD CONSTRAINT "FK_f051628403f51d0b0e11c1aabf4" FOREIGN KEY ("userId") REFERENCES "gap_user"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`,
+        );
+        await queryRunner.query(
+            `ALTER TABLE "saved_search_notification" ADD CONSTRAINT "FK_a9dd34a7c89d31227a4b4e2eb85" FOREIGN KEY ("userId") REFERENCES "gap_user"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`,
+        );
+        await queryRunner.query(
+            `ALTER TABLE "subscription" ADD CONSTRAINT "FK_cc906b4bc892b048f1b654d2aa0" FOREIGN KEY ("userId") REFERENCES "gap_user"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`,
+        );
+        await queryRunner.query(
+            `ALTER TABLE "saved_search" ADD CONSTRAINT "FK_397e5fcfff614ace7edf6831d5b" FOREIGN KEY ("userId") REFERENCES "gap_user"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`,
+        );
     }
-
 }

--- a/src/migration/1700651901473-cascade-delete-user.ts
+++ b/src/migration/1700651901473-cascade-delete-user.ts
@@ -1,0 +1,32 @@
+import {MigrationInterface, QueryRunner} from "typeorm";
+
+export class cascadeDeleteUser1700651901473 implements MigrationInterface {
+    name = 'cascadeDeleteUser1700651901473'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "saved_search" DROP CONSTRAINT "FK_397e5fcfff614ace7edf6831d5b"`);
+        await queryRunner.query(`ALTER TABLE "subscription" DROP CONSTRAINT "FK_cc906b4bc892b048f1b654d2aa0"`);
+        await queryRunner.query(`ALTER TABLE "saved_search_notification" DROP CONSTRAINT "FK_a9dd34a7c89d31227a4b4e2eb85"`);
+        await queryRunner.query(`ALTER TABLE "unsubscribe" DROP CONSTRAINT "FK_f051628403f51d0b0e11c1aabf4"`);
+        await queryRunner.query(`ALTER TABLE "newsletter" DROP CONSTRAINT "FK_20f63020913bbfdc1835e080549"`);
+        await queryRunner.query(`ALTER TABLE "saved_search" ADD CONSTRAINT "FK_397e5fcfff614ace7edf6831d5b" FOREIGN KEY ("userId") REFERENCES "gap_user"("id") ON DELETE CASCADE ON UPDATE NO ACTION`);
+        await queryRunner.query(`ALTER TABLE "subscription" ADD CONSTRAINT "FK_cc906b4bc892b048f1b654d2aa0" FOREIGN KEY ("userId") REFERENCES "gap_user"("id") ON DELETE CASCADE ON UPDATE NO ACTION`);
+        await queryRunner.query(`ALTER TABLE "saved_search_notification" ADD CONSTRAINT "FK_a9dd34a7c89d31227a4b4e2eb85" FOREIGN KEY ("userId") REFERENCES "gap_user"("id") ON DELETE CASCADE ON UPDATE NO ACTION`);
+        await queryRunner.query(`ALTER TABLE "unsubscribe" ADD CONSTRAINT "FK_f051628403f51d0b0e11c1aabf4" FOREIGN KEY ("userId") REFERENCES "gap_user"("id") ON DELETE CASCADE ON UPDATE NO ACTION`);
+        await queryRunner.query(`ALTER TABLE "newsletter" ADD CONSTRAINT "FK_20f63020913bbfdc1835e080549" FOREIGN KEY ("userId") REFERENCES "gap_user"("id") ON DELETE CASCADE ON UPDATE NO ACTION`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "newsletter" DROP CONSTRAINT "FK_20f63020913bbfdc1835e080549"`);
+        await queryRunner.query(`ALTER TABLE "unsubscribe" DROP CONSTRAINT "FK_f051628403f51d0b0e11c1aabf4"`);
+        await queryRunner.query(`ALTER TABLE "saved_search_notification" DROP CONSTRAINT "FK_a9dd34a7c89d31227a4b4e2eb85"`);
+        await queryRunner.query(`ALTER TABLE "subscription" DROP CONSTRAINT "FK_cc906b4bc892b048f1b654d2aa0"`);
+        await queryRunner.query(`ALTER TABLE "saved_search" DROP CONSTRAINT "FK_397e5fcfff614ace7edf6831d5b"`);
+        await queryRunner.query(`ALTER TABLE "newsletter" ADD CONSTRAINT "FK_20f63020913bbfdc1835e080549" FOREIGN KEY ("userId") REFERENCES "gap_user"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+        await queryRunner.query(`ALTER TABLE "unsubscribe" ADD CONSTRAINT "FK_f051628403f51d0b0e11c1aabf4" FOREIGN KEY ("userId") REFERENCES "gap_user"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+        await queryRunner.query(`ALTER TABLE "saved_search_notification" ADD CONSTRAINT "FK_a9dd34a7c89d31227a4b4e2eb85" FOREIGN KEY ("userId") REFERENCES "gap_user"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+        await queryRunner.query(`ALTER TABLE "subscription" ADD CONSTRAINT "FK_cc906b4bc892b048f1b654d2aa0" FOREIGN KEY ("userId") REFERENCES "gap_user"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+        await queryRunner.query(`ALTER TABLE "saved_search" ADD CONSTRAINT "FK_397e5fcfff614ace7edf6831d5b" FOREIGN KEY ("userId") REFERENCES "gap_user"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+    }
+
+}

--- a/src/newsletter/newsletter.entity.ts
+++ b/src/newsletter/newsletter.entity.ts
@@ -23,7 +23,9 @@ export class Newsletter {
     })
     type: NewsletterType;
 
-    @ManyToOne(() => User, (user) => user.newsletterSubscriptions)
+    @ManyToOne(() => User, (user) => user.newsletterSubscriptions, {
+        onDelete: 'CASCADE',
+    })
     user: User;
 
     @CreateDateColumn({ type: 'timestamptz' })

--- a/src/notifications/v2/unsubscribe/unsubscribe.entity.ts
+++ b/src/notifications/v2/unsubscribe/unsubscribe.entity.ts
@@ -11,6 +11,7 @@ export class Unsubscribe {
     id: string;
 
     @ManyToOne(() => User, (user) => user.unsubscribeReferences, {
+        onDelete: 'CASCADE',
         eager: true,
     })
     user: User;

--- a/src/saved_search/saved_search.entity.ts
+++ b/src/saved_search/saved_search.entity.ts
@@ -25,6 +25,7 @@ export class SavedSearch {
     id: number;
 
     @ManyToOne(() => User, (user) => user.savedSearches, {
+        onDelete: 'CASCADE',
         cascade: true,
         eager: true,
     })

--- a/src/saved_search_notification/saved_search_notification.entity.ts
+++ b/src/saved_search_notification/saved_search_notification.entity.ts
@@ -20,6 +20,7 @@ export class SavedSearchNotification {
     resultsUri: string;
 
     @ManyToOne(() => User, (user) => user.savedSearchNotifications, {
+        onDelete: 'CASCADE',
         eager: true,
     })
     user: User;

--- a/src/subscription/subscription.entity.ts
+++ b/src/subscription/subscription.entity.ts
@@ -22,6 +22,8 @@ export class Subscription {
     @UpdateDateColumn({ type: 'timestamptz' })
     updatedAt: Date;
 
-    @ManyToOne(() => User, (user) => user.subscriptions)
+    @ManyToOne(() => User, (user) => user.subscriptions, {
+        onDelete: 'CASCADE',
+    })
     user: User;
 }

--- a/src/user/user.controller.spec.ts
+++ b/src/user/user.controller.spec.ts
@@ -10,8 +10,22 @@ describe('UserController', () => {
     let controller: UserController;
     let userService: UserService;
     let encryptionServiceV2: EncryptionServiceV2;
+    let mockUser: User;
 
     beforeEach(async () => {
+        mockUser = {
+            id: 1,
+            emailAddress: 'test@test.com',
+            hashedEmailAddress: 'hashed-email',
+            encryptedEmailAddress: 'encrypted-email',
+            updatedAt: new Date('2022-03-25T14:00:00.000Z'),
+            createdAt: new Date('2022-06-25T14:00:00.000Z'),
+            sub: 'my-sub',
+            subscriptions: [],
+            newsletterSubscriptions: [],
+            savedSearches: [],
+        } as User;
+
         const module: TestingModule = await Test.createTestingModule({
             controllers: [UserController],
             providers: [
@@ -25,6 +39,9 @@ describe('UserController', () => {
                     provide: UserService,
                     useValue: {
                         migrateOrCreate: jest.fn(),
+                        findBySub: jest.fn(),
+                        findByEmail: jest.fn(),
+                        delete: jest.fn(),
                     },
                 },
                 {
@@ -68,5 +85,28 @@ describe('UserController', () => {
                 isNewUser: true,
             });
         });
+    });
+    it('should delete user by sub', async () => {
+        jest.spyOn(userService, 'findBySub').mockImplementationOnce(
+            async () => mockUser,
+        );
+
+        await controller.delete('1234', undefined);
+
+        expect(userService.findBySub).toHaveBeenCalledWith('1234');
+        expect(userService.delete).toHaveBeenCalledWith(1);
+    });
+
+    it('should delete user by email', async () => {
+        jest.spyOn(userService, 'findByEmail').mockImplementationOnce(
+            async () => mockUser,
+        );
+
+        await controller.delete(undefined, 'test.user@email.gov');
+
+        expect(userService.findByEmail).toHaveBeenCalledWith(
+            'test.user@email.gov',
+        );
+        expect(userService.delete).toHaveBeenCalledWith(1);
     });
 });

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -1,6 +1,7 @@
-import { Controller, Body, Patch } from '@nestjs/common';
+import { Controller, Body, Patch, Query, Delete } from '@nestjs/common';
 import { UserService } from './user.service';
 import { EncryptionServiceV2 } from '../encryption/encryptionV2.service';
+import { User } from './user.entity';
 
 @Controller('user')
 export class UserController {
@@ -13,5 +14,15 @@ export class UserController {
     async migrate(@Body('email') email: Buffer, @Body('sub') sub: string) {
         const decryptedEmail = await this.encryptionServiceV2.decryptV2(email);
         return this.userService.migrateOrCreate(decryptedEmail, sub);
+    }
+
+    @Delete('/delete')
+    async delete(@Query('sub') sub: string, @Query('email') email: string) {
+        let user: User;
+        if (sub) user = await this.userService.findBySub(sub);
+        if (email) user = await this.userService.findByEmail(email);
+
+        this.userService.delete(user.id);
+        console.log(`Successfully deleted user ${user}`);
     }
 }

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -1,4 +1,12 @@
-import { Controller, Body, Patch, Query, Delete } from '@nestjs/common';
+import {
+    Controller,
+    Body,
+    Patch,
+    Query,
+    Delete,
+    HttpException,
+    HttpStatus,
+} from '@nestjs/common';
 import { UserService } from './user.service';
 import { EncryptionServiceV2 } from '../encryption/encryptionV2.service';
 import { User } from './user.entity';
@@ -21,6 +29,12 @@ export class UserController {
         let user: User;
         if (sub) user = await this.userService.findBySub(sub);
         if (email) user = await this.userService.findByEmail(email);
+
+        if (!user)
+            throw new HttpException(
+                'No user found with the given email or sub',
+                HttpStatus.NOT_FOUND,
+            );
 
         this.userService.delete(user.id);
         console.log(`Successfully deleted user ${user}`);


### PR DESCRIPTION
This change adds:

- new delete user endpoint that checks for sub then email
- modifies entities to cascade delete newsletter, subscriptions and saved searches if a user is deleted

Full screen recording on ticket: https://technologyprogramme.atlassian.net/browse/GAP-2306

linked PRs:

[Adds delete user endpoint by sub or email by dylanwrightCO · Pull Request #96 · cabinetoffice/gap-find-web](https://github.com/cabinetoffice/gap-find-web/pull/96) 

[Adds call to delete find user by sub or email by dylanwrightCO · Pull Request #154 · cabinetoffice/gap-user-service](https://github.com/cabinetoffice/gap-user-service/pull/154)
