### PR TITLE
Run typeorm migrations on startup

### DIFF
--- a/src/app.migrations.ts
+++ b/src/app.migrations.ts
@@ -1,0 +1,45 @@
+import { Initial1648557645257 } from './migration/1648557645257-Initial';
+import { createUserTable1651661608553 } from './migration/1651661608553-create-user-table';
+import { createUsersFromSubscriptions1651661636362 } from './migration/1651661636362-create-users-from-subscriptions';
+import { removeEmailFromSubscriptions1651662245821 } from './migration/1651662245821-remove-email-from-subscriptions';
+import { createNewsletterTableWithUserTableFk1651842965660 } from './migration/1651842965660-create-newsletter-table-with-user-table-fk';
+import { newsletterAndSubscriptionUpdateDateColumns1652662540627 } from './migration/1652662540627-newsletterAndSubscriptionUpdateDateColumns';
+import { createSavedSearchTable1659002668795 } from './migration/1659002668795-create-saved-search-table';
+import { addNameColumnToSavedSearch1659020134990 } from './migration/1659020134990-add-name-column-to-saved-search';
+import { makeSavedSearchFieldsNullable1659445450675 } from './migration/1659445450675-make-saved-search-fields-nullable';
+import { addSavedSearchNotificationTable1665671427114 } from './migration/1665671427114-add-saved-search-notification-table';
+import { updateSchedulerEnum1665749813682 } from './migration/1665749813682-update-scheduler-enum';
+import { setSavedSearchNotificationEmailStatusToFalse1665757421703 } from './migration/1665757421703-set-saved-search-notification-email-status-to-false';
+import { addCreatedAtToSavedSearch1666103745975 } from './migration/1666103745975-add-createdAt-to-saved-search';
+import { addSavedSearchNotificationScheduledJobType1666190904662 } from './migration/1666190904662-add-saved-search-notification-scheduled-job-type';
+import { addSubColumnToGapUserTable1695306162401 } from './migration/1695306162401-add-sub-column-to-gap-user-table';
+import { updateNewletterTypeAndScheduledJobTypeColumns1652100294076 } from './migration/1652100294076-updateNewletterTypeAndScheduledJobTypeColumns';
+import { linkSavedSearchToSavedSearchNotification1696880123239 } from './migration/1696880123239-linkSaved_searchToSaved_search_notification';
+import { addUnsubscribeReferenceTable1697725143044 } from './migration/1697725143044-addUnsubscribeReferenceTable';
+import { cascadeDeleteUser1700651901473 } from './migration/1700651901473-cascade-delete-user';
+import { addScheduledJobLock1707740504090 } from './migration/1707740504090-addScheduledJobLock';
+
+const migrations = [
+    Initial1648557645257,
+    createUserTable1651661608553,
+    createUsersFromSubscriptions1651661636362,
+    removeEmailFromSubscriptions1651662245821,
+    createNewsletterTableWithUserTableFk1651842965660,
+    updateNewletterTypeAndScheduledJobTypeColumns1652100294076,
+    newsletterAndSubscriptionUpdateDateColumns1652662540627,
+    createSavedSearchTable1659002668795,
+    addNameColumnToSavedSearch1659020134990,
+    makeSavedSearchFieldsNullable1659445450675,
+    addSavedSearchNotificationTable1665671427114,
+    updateSchedulerEnum1665749813682,
+    setSavedSearchNotificationEmailStatusToFalse1665757421703,
+    addCreatedAtToSavedSearch1666103745975,
+    addSavedSearchNotificationScheduledJobType1666190904662,
+    addSubColumnToGapUserTable1695306162401,
+    linkSavedSearchToSavedSearchNotification1696880123239,
+    addUnsubscribeReferenceTable1697725143044,
+    cascadeDeleteUser1700651901473,
+    addScheduledJobLock1707740504090,
+];
+
+export { migrations };

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -34,7 +34,7 @@ import { migrations } from './app.migrations';
             useFactory: async () => {
                 return {
                     type: 'postgres',
-                    url: 'postgres://john:root@localhost:5432/find-be-2',
+                    url: process.env.DATABASE_URL,
                     entities: [
                         ScheduledJob,
                         Subscription,

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -26,6 +26,7 @@ import { UserModule } from './user/user.module';
 import { HealthCheckModule } from './healthCheck/healthCheck.module';
 import { v2NotificationsModule } from './notifications/v2/v2notifications.module';
 import { Unsubscribe } from './notifications/v2/unsubscribe/unsubscribe.entity';
+import { migrations } from './app.migrations';
 
 @Module({
     imports: [
@@ -33,7 +34,7 @@ import { Unsubscribe } from './notifications/v2/unsubscribe/unsubscribe.entity';
             useFactory: async () => {
                 return {
                     type: 'postgres',
-                    url: process.env.DATABASE_URL,
+                    url: 'postgres://john:root@localhost:5432/find-be-2',
                     entities: [
                         ScheduledJob,
                         Subscription,
@@ -45,6 +46,9 @@ import { Unsubscribe } from './notifications/v2/unsubscribe/unsubscribe.entity';
                     ],
                     synchronize: false,
                     ssl: process.env.DATABASE_SSL === 'true',
+                    migrations,
+                    migrationsTableName: 'migrations',
+                    migrationsRun: true,
                 };
             },
         }),

--- a/src/migration/1652100294076-updateNewletterTypeAndScheduledJobTypeColumns.ts
+++ b/src/migration/1652100294076-updateNewletterTypeAndScheduledJobTypeColumns.ts
@@ -1,9 +1,9 @@
 import { MigrationInterface, QueryRunner } from 'typeorm';
 
-export class updateNewsletterTypeAndScheduledJobTypeColumns1652100294076
+export class updateNewletterTypeAndScheduledJobTypeColumns1652100294076
     implements MigrationInterface
 {
-    name = 'updateNewsletterTypeAndScheduledJobTypeColumns1652100294076';
+    name = 'updateNewletterTypeAndScheduledJobTypeColumns1652100294076';
 
     public async up(queryRunner: QueryRunner): Promise<void> {
         await queryRunner.query(`ALTER TABLE "newsletter" DROP COLUMN "type"`);


### PR DESCRIPTION
## Description

Ticket # and link

Config changes to app.module to run each migration on startup. Also reverts a migration class name change which has broken the typeorm migration:run command in sandbox (it's trying to run the newly named migration despite already being applied in all environments)

The library docs suggest we can point the migrations field to a directory `migration/**.ts` instead of importing each class but it doesn't work!

## Type of change

Please check the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes:

- [ ] Unit Test

- [ ] Integration Test (if applicable)

- [ ] End to End Test (if applicable)

## Screenshots (if appropriate):

Please attach screenshots of the change if it is a UI change:

# Checklist:

- [ ] If I have listed dependencies above, I have ensured that they are present in the target branch.
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation where applicable.
- [ ] I have ran cypress tests and they all pass locally.
